### PR TITLE
Mark free_dead_node funcion as unsafe

### DIFF
--- a/core/src/check.rs
+++ b/core/src/check.rs
@@ -557,7 +557,7 @@ pub fn infer_all(
   ctx.push((nam.to_string(), Uses::None, &mut dom_dag));
   check(rec, defs, ctx, Uses::None, img, &mut typ, should_count)?;
   ctx.pop();
-  free_dead_node(dom_dag);
+  unsafe { free_dead_node(dom_dag) };
   Ok(typ)
 }
 

--- a/core/src/dag.rs
+++ b/core/src/dag.rs
@@ -531,7 +531,7 @@ pub fn add_to_parents(node: DAGPtr, plink: NonNull<Parents>) {
 }
 
 /// Free parentless nodes.
-pub fn free_dead_node(node: DAGPtr) {
+pub unsafe fn free_dead_node(node: DAGPtr) {
   unsafe {
     match node {
       DAGPtr::Lam(link) => {
@@ -539,7 +539,7 @@ pub fn free_dead_node(node: DAGPtr) {
         let new_bod_parents = bod_ref.unlink_node();
         set_parents(*bod, new_bod_parents);
         if new_bod_parents.is_none() {
-          free_dead_node(*bod)
+          (*bod)
         }
         Box::from_raw(link.as_ptr());
       }
@@ -548,7 +548,7 @@ pub fn free_dead_node(node: DAGPtr) {
         let new_bod_parents = bod_ref.unlink_node();
         set_parents(*bod, new_bod_parents);
         if new_bod_parents.is_none() {
-          free_dead_node(*bod)
+          unsafe { free_dead_node(*bod) }
         }
         Box::from_raw(link.as_ptr());
       }


### PR DESCRIPTION
https://github.com/kitkerit/rust-bound/blob/ae681f6aaacb3631872a74d5ce5c28bdf52afd51/core/src/dag.rs#L534-L670

hello, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately. Marking them unsafe also means that callers must make sure they know what they're doing.